### PR TITLE
Add share song button

### DIFF
--- a/src/lib/presentation/widgets/song_bottom_sheet.dart
+++ b/src/lib/presentation/widgets/song_bottom_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:get_it/get_it.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../domain/entities/album.dart';
 import '../../domain/entities/artist.dart';
@@ -135,6 +136,17 @@ class _SongBottomSheetState extends State<SongBottomSheet> {
                         style: TEXT_SMALL_SUBTITLE.copyWith(height: 1.2),
                       ),
                     ],
+                  ),
+                ),
+                SizedBox(
+                  height: 64.0,
+                  child: Center(
+                    child: IconButton(
+                      onPressed: () {
+                        Share.share('${song.artist} - ${song.title}');
+                      },
+                      icon: const Icon(Icons.share),
+                    )
                   ),
                 ),
                 SizedBox(

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -241,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.3"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+4"
   crypto:
     dependency: transitive
     description:
@@ -862,6 +870,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: ed3fcea4f789ed95913328e629c0c53e69e80e08b6c24542f1b3576046c614e8
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "0c6e61471bd71b04a138b8b588fa388e66d8b005e6f2deda63371c5c505a0981"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   shelf:
     dependency: transitive
     description:
@@ -1083,6 +1107,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "207f4ddda99b95b4d4868320a352d374b0b7e05eefad95a4a26f57da413443f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: bfdfa402f1f3298637d71ca8ecfe840b4696698213d5346e9d12d4ab647ee2ea
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: cc26720eefe98c1b71d85f9dc7ef0cada5132617046369d9dc296b3ecaa5cbb4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.18"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "7967065dd2b5fccc18c653b97958fdf839c5478c28e767c61ee879f4e7882422"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   uuid:
     dependency: transitive
     description:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   permission_handler: ^10.2.0  # MIT
   provider: ^6.0.2  # MIT
   reorderables: ^0.6.0  # MIT
+  share_plus: ^7.0.2
   sqlite3_flutter_libs: ^0.5.0  # MIT
   string_similarity: ^2.0.0  # MIT
   text_scroll: ^0.2.0  # MIT


### PR DESCRIPTION
This adds a button to share the song to song_bottom_sheet. This is one feature I was missing when I switched from Spotify to Mucke. Now obviously we can't share a link to the song so I opted for a easily searchable string like this: "${song.artist} - ${song.title}